### PR TITLE
Add properties to ConnectionProfile

### DIFF
--- a/src/Cli/ConsoleUI.cs
+++ b/src/Cli/ConsoleUI.cs
@@ -423,8 +423,16 @@ internal sealed class ConsoleUI
                             + $"[bold]Host:[/] {profile.Host}\n"
                             + $"[bold]Port:[/] {profile.Port}\n"
                             + $"[bold]Username:[/] {profile.Username}\n"
-                            + (profile.KeyPath != null ? $"[bold]Key Path:[/] {profile.KeyPath}\n" : "")
-                            + (profile.Password != null ? $"[bold]Password:[/] {profile.Password}\n" : "")
+                            + (
+                                profile.KeyPath != null
+                                    ? $"[bold]Key Path:[/] {profile.KeyPath}\n"
+                                    : ""
+                            )
+                            + (
+                                profile.Password != null
+                                    ? $"[bold]Password:[/] {profile.Password}\n"
+                                    : ""
+                            )
                             + $"[bold]ID:[/] [dim]{profile.Id}[/]",
                         "create connection profile"
                     );
@@ -509,8 +517,16 @@ internal sealed class ConsoleUI
                             + $"[bold]Host:[/] {profile.Host}\n"
                             + $"[bold]Port:[/] {profile.Port}\n"
                             + $"[bold]Username:[/] {profile.Username}\n"
-                            + (profile.KeyPath != null ? $"[bold]Key Path:[/] {profile.KeyPath}\n" : "")
-                            + (profile.Password != null ? $"[bold]Password:[/] {profile.Password}\n" : "")
+                            + (
+                                profile.KeyPath != null
+                                    ? $"[bold]Key Path:[/] {profile.KeyPath}\n"
+                                    : ""
+                            )
+                            + (
+                                profile.Password != null
+                                    ? $"[bold]Password:[/] {profile.Password}\n"
+                                    : ""
+                            )
                             + $"[bold]ID:[/] [dim]{profile.Id}[/]",
                         "update connection profile"
                     );

--- a/src/Cli/ConsoleUI.cs
+++ b/src/Cli/ConsoleUI.cs
@@ -282,6 +282,37 @@ internal sealed class ConsoleUI
         return AnsiConsole.Prompt(prompt);
     }
 
+    private static string? PromptForKeyPath(string? defaultValue = null)
+    {
+        var prompt = new TextPrompt<string>("Enter [blue]private key path[/] (optional):")
+            .PromptStyle("cyan")
+            .AllowEmpty();
+
+        if (!string.IsNullOrWhiteSpace(defaultValue))
+        {
+            prompt = prompt.DefaultValue(defaultValue).ShowDefaultValue(true);
+        }
+
+        var result = AnsiConsole.Prompt(prompt);
+        return string.IsNullOrWhiteSpace(result) ? null : result;
+    }
+
+    private static string? PromptForPassword(string? defaultValue = null)
+    {
+        var prompt = new TextPrompt<string>("Enter [blue]password[/] (optional):")
+            .PromptStyle("cyan")
+            .Secret()
+            .AllowEmpty();
+
+        if (!string.IsNullOrWhiteSpace(defaultValue))
+        {
+            prompt = prompt.DefaultValue(defaultValue).ShowDefaultValue(true);
+        }
+
+        var result = AnsiConsole.Prompt(prompt);
+        return string.IsNullOrWhiteSpace(result) ? null : result;
+    }
+
     private static void DisplayErrorOrResult<T>(
         ErrorOr<T> result,
         string successMessage,
@@ -351,6 +382,12 @@ internal sealed class ConsoleUI
         // Get username information
         var username = PromptForUsername();
 
+        // Get optional key path
+        var keyPath = PromptForKeyPath();
+
+        // Get optional password
+        var password = PromptForPassword();
+
         await AnsiConsole
             .Status()
             .Spinner(Spinner.Known.Dots)
@@ -364,7 +401,9 @@ internal sealed class ConsoleUI
                         connectionType,
                         host,
                         port,
-                        username
+                        username,
+                        keyPath,
+                        password
                     );
 
                     // Call the service
@@ -384,6 +423,8 @@ internal sealed class ConsoleUI
                             + $"[bold]Host:[/] {profile.Host}\n"
                             + $"[bold]Port:[/] {profile.Port}\n"
                             + $"[bold]Username:[/] {profile.Username}\n"
+                            + (profile.KeyPath != null ? $"[bold]Key Path:[/] {profile.KeyPath}\n" : "")
+                            + (profile.Password != null ? $"[bold]Password:[/] {profile.Password}\n" : "")
                             + $"[bold]ID:[/] [dim]{profile.Id}[/]",
                         "create connection profile"
                     );
@@ -426,6 +467,12 @@ internal sealed class ConsoleUI
         // Get username information with current value as default
         var username = PromptForUsername(connectionProfile.Username);
 
+        // Get optional key path with current value as default
+        var keyPath = PromptForKeyPath(connectionProfile.KeyPath);
+
+        // Get optional password with current value as default
+        var password = PromptForPassword(connectionProfile.Password);
+
         await AnsiConsole
             .Status()
             .Spinner(Spinner.Known.Dots)
@@ -440,7 +487,9 @@ internal sealed class ConsoleUI
                         connectionType,
                         host,
                         port,
-                        username
+                        username,
+                        keyPath,
+                        password
                     );
 
                     // Call the service
@@ -460,6 +509,8 @@ internal sealed class ConsoleUI
                             + $"[bold]Host:[/] {profile.Host}\n"
                             + $"[bold]Port:[/] {profile.Port}\n"
                             + $"[bold]Username:[/] {profile.Username}\n"
+                            + (profile.KeyPath != null ? $"[bold]Key Path:[/] {profile.KeyPath}\n" : "")
+                            + (profile.Password != null ? $"[bold]Password:[/] {profile.Password}\n" : "")
                             + $"[bold]ID:[/] [dim]{profile.Id}[/]",
                         "update connection profile"
                     );
@@ -542,8 +593,8 @@ internal sealed class ConsoleUI
                     Host: connectionProfile.Host,
                     Port: connectionProfile.Port,
                     Username: connectionProfile.Username,
-                    KeyPath: null,
-                    Password: "test"
+                    KeyPath: connectionProfile.KeyPath,
+                    Password: connectionProfile.Password
                 );
 
                 AnsiConsole.MarkupLine($"[green]Connecting to {connectionProfile.Name}...[/]");

--- a/src/Cli/ConsoleUI.cs
+++ b/src/Cli/ConsoleUI.cs
@@ -219,6 +219,69 @@ internal sealed class ConsoleUI
         return AnsiConsole.Prompt(prompt);
     }
 
+    private static string PromptForHost(string? defaultValue = null)
+    {
+        var prompt = new TextPrompt<string>("Enter [blue]host[/] (IP address or hostname):")
+            .PromptStyle("cyan")
+            .ValidationErrorMessage("[red]Host cannot be empty[/]")
+            .Validate(input =>
+            {
+                if (string.IsNullOrWhiteSpace(input))
+                    return ValidationResult.Error("[red]Host is required[/]");
+
+                return ValidationResult.Success();
+            });
+
+        if (!string.IsNullOrWhiteSpace(defaultValue))
+        {
+            prompt = prompt.DefaultValue(defaultValue).ShowDefaultValue(true);
+        }
+
+        return AnsiConsole.Prompt(prompt);
+    }
+
+    private static ushort PromptForPort(ushort? defaultValue = null)
+    {
+        var prompt = new TextPrompt<ushort>("Enter [blue]port[/]:")
+            .PromptStyle("cyan")
+            .ValidationErrorMessage("[red]Please enter a valid port number (1-65535)[/]")
+            .Validate(port =>
+            {
+                if (port is < 1 or > 65535)
+                    return ValidationResult.Error("[red]Port must be between 1 and 65535[/]");
+
+                return ValidationResult.Success();
+            });
+
+        if (defaultValue.HasValue)
+        {
+            prompt = prompt.DefaultValue(defaultValue.Value).ShowDefaultValue(true);
+        }
+
+        return AnsiConsole.Prompt(prompt);
+    }
+
+    private static string PromptForUsername(string? defaultValue = null)
+    {
+        var prompt = new TextPrompt<string>("Enter [blue]username[/]:")
+            .PromptStyle("cyan")
+            .ValidationErrorMessage("[red]Username cannot be empty[/]")
+            .Validate(input =>
+            {
+                if (string.IsNullOrWhiteSpace(input))
+                    return ValidationResult.Error("[red]Username is required[/]");
+
+                return ValidationResult.Success();
+            });
+
+        if (!string.IsNullOrWhiteSpace(defaultValue))
+        {
+            prompt = prompt.DefaultValue(defaultValue).ShowDefaultValue(true);
+        }
+
+        return AnsiConsole.Prompt(prompt);
+    }
+
     private static void DisplayErrorOrResult<T>(
         ErrorOr<T> result,
         string successMessage,
@@ -279,6 +342,15 @@ internal sealed class ConsoleUI
         // Get connection type selection
         var connectionType = PromptForConnectionType();
 
+        // Get host information
+        var host = PromptForHost();
+
+        // Get port information
+        var port = PromptForPort();
+
+        // Get username information
+        var username = PromptForUsername();
+
         await AnsiConsole
             .Status()
             .Spinner(Spinner.Known.Dots)
@@ -287,7 +359,13 @@ internal sealed class ConsoleUI
                 async _ =>
                 {
                     // Create the request
-                    var request = new CreateConnectionProfileRequest(name, connectionType);
+                    var request = new CreateConnectionProfileRequest(
+                        name,
+                        connectionType,
+                        host,
+                        port,
+                        username
+                    );
 
                     // Call the service
                     var result = await _connectionProfilesService.CreateAsync(
@@ -303,6 +381,9 @@ internal sealed class ConsoleUI
                         profile =>
                             $"[bold]Name:[/] {profile.Name}\n"
                             + $"[bold]Type:[/] {profile.ConnectionType}\n"
+                            + $"[bold]Host:[/] {profile.Host}\n"
+                            + $"[bold]Port:[/] {profile.Port}\n"
+                            + $"[bold]Username:[/] {profile.Username}\n"
                             + $"[bold]ID:[/] [dim]{profile.Id}[/]",
                         "create connection profile"
                     );
@@ -336,6 +417,15 @@ internal sealed class ConsoleUI
         // Get connection type selection with current value as default
         var connectionType = PromptForConnectionType(connectionProfile.ConnectionType);
 
+        // Get host information with current value as default
+        var host = PromptForHost(connectionProfile.Host);
+
+        // Get port information with current value as default
+        var port = PromptForPort(connectionProfile.Port);
+
+        // Get username information with current value as default
+        var username = PromptForUsername(connectionProfile.Username);
+
         await AnsiConsole
             .Status()
             .Spinner(Spinner.Known.Dots)
@@ -347,7 +437,10 @@ internal sealed class ConsoleUI
                     var request = new UpdateConnectionProfileRequest(
                         connectionProfile.Id,
                         name,
-                        connectionType
+                        connectionType,
+                        host,
+                        port,
+                        username
                     );
 
                     // Call the service
@@ -364,6 +457,9 @@ internal sealed class ConsoleUI
                         profile =>
                             $"[bold]Name:[/] {profile.Name}\n"
                             + $"[bold]Type:[/] {profile.ConnectionType}\n"
+                            + $"[bold]Host:[/] {profile.Host}\n"
+                            + $"[bold]Port:[/] {profile.Port}\n"
+                            + $"[bold]Username:[/] {profile.Username}\n"
                             + $"[bold]ID:[/] [dim]{profile.Id}[/]",
                         "update connection profile"
                     );
@@ -443,9 +539,9 @@ internal sealed class ConsoleUI
             case ConnectionType.SSH:
             {
                 var request = new SshConnectionRequest(
-                    Host: "192.168.10.24",
-                    Port: 1122,
-                    Username: "host",
+                    Host: connectionProfile.Host,
+                    Port: connectionProfile.Port,
+                    Username: connectionProfile.Username,
                     KeyPath: null,
                     Password: "test"
                 );

--- a/src/Core/Common/Constants/ApplicationConstants.cs
+++ b/src/Core/Common/Constants/ApplicationConstants.cs
@@ -3,4 +3,6 @@ namespace ConnectionManager.Core.Common.Constants;
 internal static class ApplicationConstants
 {
     internal const int DefaultMaxStringLength = 512;
+    internal const ushort MinPort = 1;
+    internal const ushort MaxPort = 65535;
 }

--- a/src/Core/Data/Configuration/ConnectionProfileConfiguration.cs
+++ b/src/Core/Data/Configuration/ConnectionProfileConfiguration.cs
@@ -14,5 +14,9 @@ internal sealed class ConnectionProfileConfiguration : IEntityTypeConfiguration<
         builder.HasIndex(cp => cp.Name).IsUnique();
 
         builder.Property(cp => cp.ConnectionType).IsRequired();
+
+        builder.Property(cp => cp.Host).IsRequired();
+        builder.Property(cp => cp.Port).IsRequired();
+        builder.Property(cp => cp.Username).IsRequired();
     }
 }

--- a/src/Core/Data/Configuration/ConnectionProfileConfiguration.cs
+++ b/src/Core/Data/Configuration/ConnectionProfileConfiguration.cs
@@ -18,5 +18,8 @@ internal sealed class ConnectionProfileConfiguration : IEntityTypeConfiguration<
         builder.Property(cp => cp.Host).IsRequired();
         builder.Property(cp => cp.Port).IsRequired();
         builder.Property(cp => cp.Username).IsRequired();
+        
+        builder.Property(cp => cp.KeyPath).IsRequired(false);
+        builder.Property(cp => cp.Password).IsRequired(false);
     }
 }

--- a/src/Core/Data/Configuration/ConnectionProfileConfiguration.cs
+++ b/src/Core/Data/Configuration/ConnectionProfileConfiguration.cs
@@ -18,7 +18,7 @@ internal sealed class ConnectionProfileConfiguration : IEntityTypeConfiguration<
         builder.Property(cp => cp.Host).IsRequired();
         builder.Property(cp => cp.Port).IsRequired();
         builder.Property(cp => cp.Username).IsRequired();
-        
+
         builder.Property(cp => cp.KeyPath).IsRequired(false);
         builder.Property(cp => cp.Password).IsRequired(false);
     }

--- a/src/Core/Data/Migrations/20250701201106_AddConnectionProfileHostPortUsername.Designer.cs
+++ b/src/Core/Data/Migrations/20250701201106_AddConnectionProfileHostPortUsername.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ConnectionManager.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace ConnectionManager.Core.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250701201106_AddConnectionProfileHostPortUsername")]
+    partial class AddConnectionProfileHostPortUsername
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.6");

--- a/src/Core/Data/Migrations/20250701201106_AddConnectionProfileHostPortUsername.cs
+++ b/src/Core/Data/Migrations/20250701201106_AddConnectionProfileHostPortUsername.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConnectionManager.Core.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddConnectionProfileHostPortUsername : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Host",
+                table: "ConnectionProfiles",
+                type: "TEXT",
+                maxLength: 512,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<ushort>(
+                name: "Port",
+                table: "ConnectionProfiles",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: (ushort)0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Username",
+                table: "ConnectionProfiles",
+                type: "TEXT",
+                maxLength: 512,
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Host",
+                table: "ConnectionProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "Port",
+                table: "ConnectionProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "Username",
+                table: "ConnectionProfiles");
+        }
+    }
+}

--- a/src/Core/Data/Migrations/20250701204438_AddConnectionProfileKeyPathPassword.Designer.cs
+++ b/src/Core/Data/Migrations/20250701204438_AddConnectionProfileKeyPathPassword.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using ConnectionManager.Core.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace ConnectionManager.Core.Data.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250701204438_AddConnectionProfileKeyPathPassword")]
+    partial class AddConnectionProfileKeyPathPassword
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.6");

--- a/src/Core/Data/Migrations/20250701204438_AddConnectionProfileKeyPathPassword.cs
+++ b/src/Core/Data/Migrations/20250701204438_AddConnectionProfileKeyPathPassword.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ConnectionManager.Core.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddConnectionProfileKeyPathPassword : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "KeyPath",
+                table: "ConnectionProfiles",
+                type: "TEXT",
+                maxLength: 512,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Password",
+                table: "ConnectionProfiles",
+                type: "TEXT",
+                maxLength: 512,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "KeyPath",
+                table: "ConnectionProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "Password",
+                table: "ConnectionProfiles");
+        }
+    }
+}

--- a/src/Core/Models/ConnectionProfile.cs
+++ b/src/Core/Models/ConnectionProfile.cs
@@ -10,4 +10,6 @@ public sealed class ConnectionProfile
     public required string Host { get; set; }
     public required ushort Port { get; set; }
     public required string Username { get; set; }
+    public string? KeyPath { get; set; }
+    public string? Password { get; set; }
 }

--- a/src/Core/Models/ConnectionProfile.cs
+++ b/src/Core/Models/ConnectionProfile.cs
@@ -6,4 +6,8 @@ public sealed class ConnectionProfile
 
     public required string Name { get; set; }
     public required ConnectionType ConnectionType { get; set; }
+
+    public required string Host { get; set; }
+    public required ushort Port { get; set; }
+    public required string Username { get; set; }
 }

--- a/src/Core/Services/Contracts/ConnectionProfiles/ConnectionProfileDTO.cs
+++ b/src/Core/Services/Contracts/ConnectionProfiles/ConnectionProfileDTO.cs
@@ -2,8 +2,22 @@ using ConnectionManager.Core.Models;
 
 namespace ConnectionManager.Core.Services.Contracts.ConnectionProfiles;
 
-public sealed record ConnectionProfileDTO(Guid Id, string Name, ConnectionType ConnectionType)
+public sealed record ConnectionProfileDTO(
+    Guid Id,
+    string Name,
+    ConnectionType ConnectionType,
+    string Host,
+    ushort Port,
+    string Username
+)
 {
     public ConnectionProfileDTO(ConnectionProfile connectionProfile)
-        : this(connectionProfile.Id, connectionProfile.Name, connectionProfile.ConnectionType) { }
+        : this(
+            connectionProfile.Id,
+            connectionProfile.Name,
+            connectionProfile.ConnectionType,
+            connectionProfile.Host,
+            connectionProfile.Port,
+            connectionProfile.Username
+        ) { }
 }

--- a/src/Core/Services/Contracts/ConnectionProfiles/ConnectionProfileDTO.cs
+++ b/src/Core/Services/Contracts/ConnectionProfiles/ConnectionProfileDTO.cs
@@ -8,7 +8,9 @@ public sealed record ConnectionProfileDTO(
     ConnectionType ConnectionType,
     string Host,
     ushort Port,
-    string Username
+    string Username,
+    string? KeyPath,
+    string? Password
 )
 {
     public ConnectionProfileDTO(ConnectionProfile connectionProfile)
@@ -18,6 +20,8 @@ public sealed record ConnectionProfileDTO(
             connectionProfile.ConnectionType,
             connectionProfile.Host,
             connectionProfile.Port,
-            connectionProfile.Username
+            connectionProfile.Username,
+            connectionProfile.KeyPath,
+            connectionProfile.Password
         ) { }
 }

--- a/src/Core/Services/Contracts/ConnectionProfiles/CreateConnectionProfileRequest.cs
+++ b/src/Core/Services/Contracts/ConnectionProfiles/CreateConnectionProfileRequest.cs
@@ -4,7 +4,13 @@ using FluentValidation;
 
 namespace ConnectionManager.Core.Services.Contracts.ConnectionProfiles;
 
-public sealed record CreateConnectionProfileRequest(string Name, ConnectionType ConnectionType);
+public sealed record CreateConnectionProfileRequest(
+    string Name,
+    ConnectionType ConnectionType,
+    string Host,
+    ushort Port,
+    string Username
+);
 
 internal sealed class CreateConnectionProfileRequestValidator
     : AbstractValidator<CreateConnectionProfileRequest>
@@ -27,5 +33,36 @@ internal sealed class CreateConnectionProfileRequestValidator
             .IsInEnum()
             .WithErrorCode(ErrorCodes.Invalid)
             .WithMessage("ConnectionType must be a valid enum value");
+
+        RuleFor(r => r.Host)
+            .NotEmpty()
+            .WithErrorCode(ErrorCodes.Required)
+            .WithMessage("Host is required");
+
+        RuleFor(r => r.Host)
+            .MaximumLength(ApplicationConstants.DefaultMaxStringLength)
+            .WithErrorCode(ErrorCodes.MaxLength)
+            .WithMessage(
+                $"Host cannot exceed {ApplicationConstants.DefaultMaxStringLength} characters"
+            );
+
+        RuleFor(r => r.Port)
+            .InclusiveBetween(ApplicationConstants.MinPort, ApplicationConstants.MaxPort)
+            .WithErrorCode(ErrorCodes.Invalid)
+            .WithMessage(
+                $"Port must be between {ApplicationConstants.MinPort} and {ApplicationConstants.MaxPort}"
+            );
+
+        RuleFor(r => r.Username)
+            .NotEmpty()
+            .WithErrorCode(ErrorCodes.Required)
+            .WithMessage("Username is required");
+
+        RuleFor(r => r.Username)
+            .MaximumLength(ApplicationConstants.DefaultMaxStringLength)
+            .WithErrorCode(ErrorCodes.MaxLength)
+            .WithMessage(
+                $"Username cannot exceed {ApplicationConstants.DefaultMaxStringLength} characters"
+            );
     }
 }

--- a/src/Core/Services/Contracts/ConnectionProfiles/CreateConnectionProfileRequest.cs
+++ b/src/Core/Services/Contracts/ConnectionProfiles/CreateConnectionProfileRequest.cs
@@ -9,7 +9,9 @@ public sealed record CreateConnectionProfileRequest(
     ConnectionType ConnectionType,
     string Host,
     ushort Port,
-    string Username
+    string Username,
+    string? KeyPath,
+    string? Password
 );
 
 internal sealed class CreateConnectionProfileRequestValidator
@@ -64,5 +66,21 @@ internal sealed class CreateConnectionProfileRequestValidator
             .WithMessage(
                 $"Username cannot exceed {ApplicationConstants.DefaultMaxStringLength} characters"
             );
+
+        RuleFor(r => r.KeyPath)
+            .MaximumLength(ApplicationConstants.DefaultMaxStringLength)
+            .WithErrorCode(ErrorCodes.MaxLength)
+            .WithMessage(
+                $"KeyPath cannot exceed {ApplicationConstants.DefaultMaxStringLength} characters"
+            )
+            .When(r => r.KeyPath is not null);
+
+        RuleFor(r => r.Password)
+            .MaximumLength(ApplicationConstants.DefaultMaxStringLength)
+            .WithErrorCode(ErrorCodes.MaxLength)
+            .WithMessage(
+                $"Password cannot exceed {ApplicationConstants.DefaultMaxStringLength} characters"
+            )
+            .When(r => r.Password is not null);
     }
 }

--- a/src/Core/Services/Contracts/ConnectionProfiles/UpdateConnectionProfileRequest.cs
+++ b/src/Core/Services/Contracts/ConnectionProfiles/UpdateConnectionProfileRequest.cs
@@ -10,7 +10,9 @@ public sealed record UpdateConnectionProfileRequest(
     ConnectionType ConnectionType,
     string Host,
     ushort Port,
-    string Username
+    string Username,
+    string? KeyPath,
+    string? Password
 );
 
 internal sealed class UpdateConnectionProfileRequestValidator
@@ -70,5 +72,21 @@ internal sealed class UpdateConnectionProfileRequestValidator
             .WithMessage(
                 $"Username cannot exceed {ApplicationConstants.DefaultMaxStringLength} characters"
             );
+
+        RuleFor(r => r.KeyPath)
+            .MaximumLength(ApplicationConstants.DefaultMaxStringLength)
+            .WithErrorCode(ErrorCodes.MaxLength)
+            .WithMessage(
+                $"KeyPath cannot exceed {ApplicationConstants.DefaultMaxStringLength} characters"
+            )
+            .When(r => r.KeyPath is not null);
+
+        RuleFor(r => r.Password)
+            .MaximumLength(ApplicationConstants.DefaultMaxStringLength)
+            .WithErrorCode(ErrorCodes.MaxLength)
+            .WithMessage(
+                $"Password cannot exceed {ApplicationConstants.DefaultMaxStringLength} characters"
+            )
+            .When(r => r.Password is not null);
     }
 }

--- a/src/Core/Services/Contracts/ConnectionProfiles/UpdateConnectionProfileRequest.cs
+++ b/src/Core/Services/Contracts/ConnectionProfiles/UpdateConnectionProfileRequest.cs
@@ -7,7 +7,10 @@ namespace ConnectionManager.Core.Services.Contracts.ConnectionProfiles;
 public sealed record UpdateConnectionProfileRequest(
     Guid Id,
     string Name,
-    ConnectionType ConnectionType
+    ConnectionType ConnectionType,
+    string Host,
+    ushort Port,
+    string Username
 );
 
 internal sealed class UpdateConnectionProfileRequestValidator
@@ -36,5 +39,36 @@ internal sealed class UpdateConnectionProfileRequestValidator
             .IsInEnum()
             .WithErrorCode(ErrorCodes.Invalid)
             .WithMessage("ConnectionType must be a valid enum value");
+
+        RuleFor(r => r.Host)
+            .NotEmpty()
+            .WithErrorCode(ErrorCodes.Required)
+            .WithMessage("Host is required");
+
+        RuleFor(r => r.Host)
+            .MaximumLength(ApplicationConstants.DefaultMaxStringLength)
+            .WithErrorCode(ErrorCodes.MaxLength)
+            .WithMessage(
+                $"Host cannot exceed {ApplicationConstants.DefaultMaxStringLength} characters"
+            );
+
+        RuleFor(r => r.Port)
+            .InclusiveBetween(ApplicationConstants.MinPort, ApplicationConstants.MaxPort)
+            .WithErrorCode(ErrorCodes.Invalid)
+            .WithMessage(
+                $"Port must be between {ApplicationConstants.MinPort} and {ApplicationConstants.MaxPort}"
+            );
+
+        RuleFor(r => r.Username)
+            .NotEmpty()
+            .WithErrorCode(ErrorCodes.Required)
+            .WithMessage("Username is required");
+
+        RuleFor(r => r.Username)
+            .MaximumLength(ApplicationConstants.DefaultMaxStringLength)
+            .WithErrorCode(ErrorCodes.MaxLength)
+            .WithMessage(
+                $"Username cannot exceed {ApplicationConstants.DefaultMaxStringLength} characters"
+            );
     }
 }

--- a/src/Core/Services/Implementations/ConnectionProfilesService.cs
+++ b/src/Core/Services/Implementations/ConnectionProfilesService.cs
@@ -103,6 +103,9 @@ internal sealed class ConnectionProfilesService : IConnectionProfilesService
             Id = Guid.NewGuid(),
             Name = request.Name,
             ConnectionType = request.ConnectionType,
+            Host = request.Host,
+            Port = request.Port,
+            Username = request.Username,
         };
 
         _dbContext.ConnectionProfiles.Add(entity);
@@ -157,6 +160,9 @@ internal sealed class ConnectionProfilesService : IConnectionProfilesService
 
         entity.Name = request.Name;
         entity.ConnectionType = request.ConnectionType;
+        entity.Host = request.Host;
+        entity.Port = request.Port;
+        entity.Username = request.Username;
 
         await _dbContext.SaveChangesAsync(cancellationToken);
 

--- a/src/Core/Services/Implementations/ConnectionProfilesService.cs
+++ b/src/Core/Services/Implementations/ConnectionProfilesService.cs
@@ -106,6 +106,8 @@ internal sealed class ConnectionProfilesService : IConnectionProfilesService
             Host = request.Host,
             Port = request.Port,
             Username = request.Username,
+            KeyPath = request.KeyPath,
+            Password = request.Password,
         };
 
         _dbContext.ConnectionProfiles.Add(entity);
@@ -163,6 +165,8 @@ internal sealed class ConnectionProfilesService : IConnectionProfilesService
         entity.Host = request.Host;
         entity.Port = request.Port;
         entity.Username = request.Username;
+        entity.KeyPath = request.KeyPath;
+        entity.Password = request.Password;
 
         await _dbContext.SaveChangesAsync(cancellationToken);
 


### PR DESCRIPTION
Add actual connection details into the ConnectionProfile model. This takes us to a first fully functional cycle of CRUD with all required properties, and then connecting to the remote. 
Password is not yet functional, this needs refinement and using `sshpass`.