### PR TITLE
Environment check on startup

### DIFF
--- a/src/Cli/ConsoleUI.cs
+++ b/src/Cli/ConsoleUI.cs
@@ -39,6 +39,8 @@ internal sealed class ConsoleUI
 
         AnsiConsole.Write(new FigletText("Connection Manager").LeftJustified().Color(Color.Blue));
 
+        await CheckEnvironment(cancellationToken);
+
         while (!cancellationToken.IsCancellationRequested)
             await ShowMainMenu(cancellationToken);
     }
@@ -54,8 +56,6 @@ internal sealed class ConsoleUI
 
     private async Task ShowMainMenu(CancellationToken cancellationToken)
     {
-        await CheckEnvironment(cancellationToken);
-
         var result = await _connectionProfilesService.GetAllAsync(cancellationToken);
         if (result.IsError)
         {

--- a/src/Cli/ConsoleUI.cs
+++ b/src/Cli/ConsoleUI.cs
@@ -130,52 +130,52 @@ internal sealed class ConsoleUI
                     r is { IsAvailable: false, Dependency.Type: SystemDependencyType.Required }
                 )
                 .ToList();
-            if (missingRequired.Count != 0)
-            {
-                var panel = new Panel(
-                    string.Join(
-                        "\n",
-                        missingRequired.Select(r =>
-                            $"• [bold]{r.Dependency.Name}[/]: {r.Dependency.Description}"
-                        )
-                    )
-                )
-                    .Header("[red]⚠️ Missing required dependencies[/]")
-                    .BorderColor(Color.Red)
-                    .RoundedBorder();
-
-                AnsiConsole.Write(panel);
-                AnsiConsole.WriteLine();
-            }
+            PrintMissingDependencies(
+                missingRequired,
+                "[red]⚠️ Missing required dependencies[/]",
+                Color.Red
+            );
 
             var missingOptional = dependencyResults
                 .Where(r =>
                     r is { IsAvailable: false, Dependency.Type: SystemDependencyType.Optional }
                 )
                 .ToList();
-
-            if (missingOptional.Count != 0)
-            {
-                var panel = new Panel(
-                    string.Join(
-                        "\n",
-                        missingOptional.Select(r =>
-                            $"• [bold]{r.Dependency.Name}[/]: {r.Dependency.Description}"
-                        )
-                    )
-                )
-                    .Header("[yellow]⚠️ Missing optional dependencies[/]")
-                    .BorderColor(Color.Yellow)
-                    .RoundedBorder();
-
-                AnsiConsole.Write(panel);
-                AnsiConsole.WriteLine();
-            }
+            PrintMissingDependencies(
+                missingOptional,
+                "[yellow]⚠️ Missing optional dependencies[/]",
+                Color.Yellow
+            );
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error checking system dependencies");
         }
+    }
+
+    private static void PrintMissingDependencies(
+        List<SystemDependencyCheckResult> missingDependencies,
+        string headerText,
+        Color borderColor
+    )
+    {
+        if (missingDependencies.Count == 0)
+            return;
+
+        var panel = new Panel(
+            string.Join(
+                "\n",
+                missingDependencies.Select(r =>
+                    $"• [bold]{r.Dependency.Name}[/]: {r.Dependency.Description}"
+                )
+            )
+        )
+            .Header(headerText)
+            .BorderColor(borderColor)
+            .RoundedBorder();
+
+        AnsiConsole.Write(panel);
+        AnsiConsole.WriteLine();
     }
 
     #endregion

--- a/src/Cli/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Cli/Extensions/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using ConnectionManager.Cli.Services.Environment;
 using ConnectionManager.Cli.Services.Ssh;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -8,6 +9,7 @@ internal static class ServiceCollectionExtensions
     internal static IServiceCollection AddCli(this IServiceCollection services)
     {
         services.AddScoped<ConsoleUI>();
+        services.AddScoped<IEnvironmentCheckService, EnvironmentCheckService>();
         services.AddScoped<ISshConnector, SshConnector>();
 
         return services;

--- a/src/Cli/Services/Environment/EnvironmentCheckService.cs
+++ b/src/Cli/Services/Environment/EnvironmentCheckService.cs
@@ -1,0 +1,88 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace ConnectionManager.Cli.Services.Environment;
+
+internal sealed class EnvironmentCheckService : IEnvironmentCheckService
+{
+    #region construction
+
+    private readonly ILogger<EnvironmentCheckService> _logger;
+
+    public EnvironmentCheckService(ILogger<EnvironmentCheckService> logger)
+    {
+        _logger = logger;
+    }
+
+    #endregion
+
+    private static readonly SystemDependency[] Dependencies =
+    [
+        new("ssh", SystemDependencyType.Required, "OpenSSH client - Required for SSH connections"),
+        new(
+            "sshpass",
+            SystemDependencyType.Optional,
+            "Password authentication helper - Needed for SSH connections using passwords"
+        ),
+    ];
+
+    public async Task<ICollection<SystemDependencyCheckResult>> CheckSystemDependenciesAsync(
+        CancellationToken cancellationToken = default
+    )
+    {
+        _logger.LogDebug("Checking system dependencies");
+
+        var results = new List<SystemDependencyCheckResult>();
+
+        foreach (var dependency in Dependencies)
+        {
+            var isAvailable = await CheckDependencyAsync(dependency.Name, cancellationToken);
+            results.Add(new SystemDependencyCheckResult(dependency, isAvailable));
+
+            _logger.LogDebug(
+                "Dependency check: {DependencyName} = {IsAvailable}",
+                dependency.Name,
+                isAvailable
+            );
+        }
+
+        return results;
+    }
+
+    private async Task<bool> CheckDependencyAsync(
+        string toolName,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "which",
+                Arguments = toolName,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            };
+
+            using var process = Process.Start(startInfo);
+            if (process == null)
+            {
+                _logger.LogWarning(
+                    "Failed to start 'which' command for dependency check: {ToolName}",
+                    toolName
+                );
+                return false;
+            }
+
+            await process.WaitForExitAsync(cancellationToken);
+            return process.ExitCode == 0;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error checking dependency: {ToolName}", toolName);
+            return false;
+        }
+    }
+}

--- a/src/Cli/Services/Environment/IEnvironmentCheckService.cs
+++ b/src/Cli/Services/Environment/IEnvironmentCheckService.cs
@@ -1,0 +1,8 @@
+namespace ConnectionManager.Cli.Services.Environment;
+
+internal interface IEnvironmentCheckService
+{
+    Task<ICollection<SystemDependencyCheckResult>> CheckSystemDependenciesAsync(
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/Cli/Services/Environment/SystemDependency.cs
+++ b/src/Cli/Services/Environment/SystemDependency.cs
@@ -1,0 +1,3 @@
+namespace ConnectionManager.Cli.Services.Environment;
+
+internal sealed record SystemDependency(string Name, SystemDependencyType Type, string Description);

--- a/src/Cli/Services/Environment/SystemDependencyCheckResult.cs
+++ b/src/Cli/Services/Environment/SystemDependencyCheckResult.cs
@@ -1,0 +1,3 @@
+namespace ConnectionManager.Cli.Services.Environment;
+
+internal sealed record SystemDependencyCheckResult(SystemDependency Dependency, bool IsAvailable);

--- a/src/Cli/Services/Environment/SystemDependencyType.cs
+++ b/src/Cli/Services/Environment/SystemDependencyType.cs
@@ -1,0 +1,8 @@
+namespace ConnectionManager.Cli.Services.Environment;
+
+internal enum SystemDependencyType : byte
+{
+    Unknown = 0,
+    Required = 1,
+    Optional = 2,
+}


### PR DESCRIPTION
On startup, an environment check is done to verify whether a set of required and optional dependencies are installed on the host system. 
(Non-blocking) warnings are displayed above the main menu on startup to notify the user. For now it only checks for ssh (required) and sshpass (optional). 